### PR TITLE
#7, remove a segfault cause by duplicating streaming computations

### DIFF
--- a/Codec/Compression/Zlib/Internal.hs
+++ b/Codec/Compression/Zlib/Internal.hs
@@ -78,12 +78,14 @@ import Control.Monad (when)
 import Control.Exception (Exception, throw, assert)
 import Control.Monad.ST.Lazy hiding (stToIO)
 import Control.Monad.ST.Strict (stToIO)
+import Control.Monad.ST.Unsafe (unsafeIOToST)
 import Data.Typeable (Typeable)
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Internal as L
 import qualified Data.ByteString          as S
 import qualified Data.ByteString.Internal as S
 import Data.Word (Word8)
+import GHC.IO (noDuplicate)
 
 import qualified Codec.Compression.Zlib.Stream as Stream
 import Codec.Compression.Zlib.Stream (Stream)
@@ -733,7 +735,7 @@ mkStateIO = stToIO Stream.mkState
 
 runStreamST :: Stream a -> Stream.State s -> ST s (a, Stream.State s)
 runStreamIO :: Stream a -> Stream.State RealWorld -> IO (a, Stream.State RealWorld)
-runStreamST strm zstate = strictToLazyST (Stream.runStream strm zstate)
+runStreamST strm zstate = strictToLazyST (unsafeIOToST noDuplicate >> Stream.runStream strm zstate)
 runStreamIO strm zstate = stToIO (Stream.runStream strm zstate)
 
 compressStreamIO :: Stream.Format -> CompressParams -> CompressStream IO

--- a/Codec/Compression/Zlib/Internal.hs
+++ b/Codec/Compression/Zlib/Internal.hs
@@ -78,7 +78,11 @@ import Control.Monad (when)
 import Control.Exception (Exception, throw, assert)
 import Control.Monad.ST.Lazy hiding (stToIO)
 import Control.Monad.ST.Strict (stToIO)
-import Control.Monad.ST.Unsafe (unsafeIOToST)
+#if __GLASGOW_HASKELL__ >= 702
+import qualified Control.Monad.ST.Unsafe as Unsafe (unsafeIOToST)
+#else
+import qualified Control.Monad.ST.Strict as Unsafe (unsafeIOToST)
+#endif
 import Data.Typeable (Typeable)
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Internal as L
@@ -735,7 +739,7 @@ mkStateIO = stToIO Stream.mkState
 
 runStreamST :: Stream a -> Stream.State s -> ST s (a, Stream.State s)
 runStreamIO :: Stream a -> Stream.State RealWorld -> IO (a, Stream.State RealWorld)
-runStreamST strm zstate = strictToLazyST (unsafeIOToST noDuplicate >> Stream.runStream strm zstate)
+runStreamST strm zstate = strictToLazyST (Unsafe.unsafeIOToST noDuplicate >> Stream.runStream strm zstate)
 runStreamIO strm zstate = stToIO (Stream.runStream strm zstate)
 
 compressStreamIO :: Stream.Format -> CompressParams -> CompressStream IO

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+
+ * Fix a segfault when reading the stream multithreaded, #7
+
 0.6.1.1 Duncan Coutts <duncan@community.haskell.org> April 2015
 
  * Fixed building with GHC 7.0 and 7.2


### PR DESCRIPTION
I've confirmed this closes the segfault with my test case.