### PR TITLE
Allow to select flushing strategy `NoFlush` is the default, but the `…

### DIFF
--- a/Codec/Compression/Zlib/Stream.hsc
+++ b/Codec/Compression/Zlib/Stream.hsc
@@ -568,6 +568,7 @@ data Flush =
   | FullFlush
   | Finish
 --  | Block -- only available in zlib 1.2 and later, uncomment if you need it.
+   deriving (Show, Eq)
 
 fromFlush :: Flush -> CInt
 fromFlush NoFlush   = #{const Z_NO_FLUSH}

--- a/test/Test/Codec/Compression/Zlib/Internal.hs
+++ b/test/Test/Codec/Compression/Zlib/Internal.hs
@@ -16,6 +16,7 @@ instance Arbitrary CompressParams where
                                     `ap` arbitrary `ap` arbitrary
                                     `ap` arbitrary `ap` arbitraryBufferSize
                                     `ap` return Nothing
+                                    `ap` arbitrary
 
 arbitraryBufferSize :: Gen Int
 arbitraryBufferSize = frequency $ [(10, return n) | n <- [1..1024]] ++
@@ -28,5 +29,6 @@ instance Arbitrary DecompressParams where
   arbitrary = return DecompressParams `ap` arbitrary
                                       `ap` arbitraryBufferSize
                                       `ap` return Nothing
+                                      `ap` arbitrary
                                       `ap` arbitrary
 

--- a/test/Test/Codec/Compression/Zlib/Stream.hs
+++ b/test/Test/Codec/Compression/Zlib/Stream.hs
@@ -16,6 +16,9 @@ instance Arbitrary Format where
 instance Arbitrary Method where
    arbitrary = return deflateMethod
 
+instance Arbitrary Flush where
+   arbitrary = elements [NoFlush]
+     -- SyncFlush, Finish, FullFlush
 
 instance Arbitrary CompressionLevel where
   arbitrary = elements $ [defaultCompression, noCompression,


### PR DESCRIPTION
Allow to select flushing strategy `NoFlush` is the default, but the `SyncFlush` is useful with the incremental protocols eg. compression with websockets