### PR TITLE
Change the window bits range from 8..15 to 9..15

### DIFF
--- a/Codec/Compression/Zlib/Stream.hsc
+++ b/Codec/Compression/Zlib/Stream.hsc
@@ -709,8 +709,8 @@ fromCompressionLevel (CompressionLevel n)
 -- usage.
 --
 -- The compression window size is the value of the the window bits raised to
--- the power 2. The window bits must be in the range @8..15@ which corresponds
--- to compression window sizes of 256b to 32Kb. The default is 15 which is also
+-- the power 2. The window bits must be in the range @9..15@ which corresponds
+-- to compression window sizes of 512b to 32Kb. The default is 15 which is also
 -- the maximum size.
 --
 -- The total amount of memory used depends on the window bits and the
@@ -737,19 +737,19 @@ data WindowBits = WindowBits Int
 defaultWindowBits :: WindowBits
 defaultWindowBits = WindowBits 15
 
--- | A specific compression window size, specified in bits in the range @8..15@
+-- | A specific compression window size, specified in bits in the range @9..15@
 --
 windowBits :: Int -> WindowBits
 windowBits n
-  | n >= 8 && n <= 15 = WindowBits n
-  | otherwise         = error "WindowBits must be in the range 8..15"
+  | n >= 9 && n <= 15 = WindowBits n
+  | otherwise         = error "WindowBits must be in the range 9..15"
 
 fromWindowBits :: Format -> WindowBits-> CInt
 fromWindowBits format bits = (formatModifier format) (checkWindowBits bits)
   where checkWindowBits DefaultWindowBits = 15
         checkWindowBits (WindowBits n)
-          | n >= 8 && n <= 15 = fromIntegral n
-          | otherwise         = error "WindowBits must be in the range 8..15"
+          | n >= 9 && n <= 15 = fromIntegral n
+          | otherwise         = error "WindowBits must be in the range 9..15"
         formatModifier Zlib       = id
         formatModifier GZip       = (+16)
         formatModifier GZipOrZlib = (+32)

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -61,10 +61,7 @@ prop_decompress_after_compress :: Format
                                -> Property
 prop_decompress_after_compress w cp dp =
    (w /= zlibFormat || decompressWindowBits dp >= compressWindowBits cp) &&
-   -- Zlib decompression has been observed to fail with both compress and decompress
-   -- window bits = 8. This seems to be contrary to the docs and to a quick reading
-   -- of the zlib source code.
-   (decompressWindowBits dp > compressWindowBits cp || decompressWindowBits dp > WindowBits 8) &&
+   (decompressWindowBits dp > compressWindowBits cp) &&
    decompressBufferSize dp > 0 && compressBufferSize cp > 0 ==>
    liftM2 (==) (decompress w dp . compress w cp) id
 

--- a/test/Test/Codec/Compression/Zlib/Stream.hs
+++ b/test/Test/Codec/Compression/Zlib/Stream.hs
@@ -24,7 +24,7 @@ instance Arbitrary CompressionLevel where
 
 
 instance Arbitrary WindowBits where
-  arbitrary = elements $ defaultWindowBits:map windowBits [8..15]
+  arbitrary = elements $ defaultWindowBits:map windowBits [9..15]
 
 
 instance Arbitrary MemoryLevel where


### PR DESCRIPTION
The zlib C lib has been changed to clarify that in fact window bits = 8 is not supported:

https://github.com/madler/zlib/commit/049578f0a1849f502834167e233f4c1d52ddcbcc

We already had a guard in one of the tests to avoid the window bits = 8 case for some formats where it had been observed to fail. The change in the C lib now makes it fail in more cases (since it had never been properly supported anyway). So the simplest thing to do is just say that 9 is the minimum value.

Credit to @trofi for notifying and then tracking down the root cause of the failure with newer versions of the C lib.

This fixes issue #11.