### PR TITLE
`zlib-0.6.2.3` Release Prep

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,6 @@
 See also http://pvp.haskell.org/faq
 
-0.6.2.3 Emily Pillmore <emilypi@cohomolo.gy> February 2020
+0.6.2.3 Emily Pillmore <emilypi@cohomolo.gy> February 2021
 
  * Add support for bytestring-0.11.0.0
 

--- a/changelog
+++ b/changelog
@@ -1,5 +1,9 @@
 See also http://pvp.haskell.org/faq
 
+0.6.2.3 Emily Pillmore <emilypi@cohomolo.gy> February 2020
+
+ * Add support for bytestring-0.11.0.0
+
 0.6.2.2 Julian Ospald <hasufell@posteo.de> August 2020
 
  * Bump bundled zlib to 1.2.11, fixes #26

--- a/zlib.cabal
+++ b/zlib.cabal
@@ -1,6 +1,6 @@
 cabal-version:   >= 1.10
 name:            zlib
-version:         0.6.2.2
+version:         0.6.2.3
 
 copyright:       (c) 2006-2016 Duncan Coutts
 license:         BSD3


### PR DESCRIPTION
This PR does the following: 

* bump zlib version
*  add changelog entry for bytestring >=0.11 support

See the full changeset [here](https://github.com/haskell/zlib/compare/866e10f283c2afe894bda620ed9051aee3a7227e..67ca7423a682b6bf57c15ba1f511df798bcfcac4). 