### PR TITLE
license is actually BSD-2-clause

### DIFF
--- a/zlib.cabal
+++ b/zlib.cabal
@@ -3,7 +3,7 @@ name:            zlib
 version:         0.6.3.0
 
 copyright:       (c) 2006-2016 Duncan Coutts
-license:         BSD3
+license:         BSD2
 license-file:    LICENSE
 author:          Duncan Coutts <duncan@community.haskell.org>
 maintainer:      Duncan Coutts <duncan@community.haskell.org>, Andrew Lelechenko <andrew.lelechenko@gmail.com>, Emily Pillmore <emilypi@cohomolo.gy>, Herbert Valerio Riedel <hvr@gnu.org>


### PR DESCRIPTION
adding an empty clause doesn't make BSD2 into BSD3 :-)

The license tweak 55db10aed should also be reverted really: I can add that