### PR TITLE
Correct signatures for `FinalizerPtr`s

### DIFF
--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -39,3 +39,37 @@ jobs:
       run: |
         cd zlib-*/
         cabal haddock
+
+  wasi:
+    runs-on: ubuntu-latest
+    env:
+      GHC_WASM_META_REV: c0aa3bb7d88bb6ec809210e17658dd1ed64ba66c
+    strategy:
+      matrix:
+        ghc: ['9.6', '9.8']
+      fail-fast: false
+    steps:
+    - name: setup-ghc-wasm32-wasi
+      run: |
+        cd $(mktemp -d)
+        curl -L https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/archive/$GHC_WASM_META_REV/ghc-wasm-meta.tar.gz | tar xz --strip-components=1
+        ./setup.sh
+        ~/.ghc-wasm/add_to_github_path.sh
+      env:
+        FLAVOUR: ${{ matrix.ghc }}
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.ghc-wasm/.cabal/store
+        key: wasi-${{ runner.os }}-${{ env.GHC_WASM_META_REV }}-flavour-${{ matrix.ghc }}-${{ github.sha }}
+        restore-keys: |
+          wasi-${{ runner.os }}-${{ env.GHC_WASM_META_REV }}-flavour-${{ matrix.ghc }}-
+    - name: Build
+      run: |
+        mv cabal.project.wasi cabal.project.local
+        wasm32-wasi-cabal build --enable-tests
+        wasm32-wasi-cabal list-bin test:tests
+    - name: Test
+      run: |
+        wasmtime.sh $(wasm32-wasi-cabal list-bin test:tests)

--- a/Codec/Compression/Zlib/Stream.hsc
+++ b/Codec/Compression/Zlib/Stream.hsc
@@ -1098,7 +1098,7 @@ c_deflateInit2 z a b c d e =
 foreign import ccall SAFTY "zlib.h inflate"
   c_inflate :: StreamState -> CInt -> IO CInt
 
-foreign import ccall unsafe "zlib.h &inflateEnd"
+foreign import ccall unsafe "hs-zlib.h &_hs_zlib_inflateEnd"
   c_inflateEnd :: FinalizerPtr StreamState
 
 foreign import ccall unsafe "zlib.h inflateReset"
@@ -1119,7 +1119,7 @@ foreign import ccall unsafe "zlib.h inflateSetDictionary"
 foreign import ccall SAFTY "zlib.h deflate"
   c_deflate :: StreamState -> CInt -> IO CInt
 
-foreign import ccall unsafe "zlib.h &deflateEnd"
+foreign import ccall unsafe "hs-zlib.h &_hs_zlib_deflateEnd"
   c_deflateEnd :: FinalizerPtr StreamState
 
 foreign import ccall unsafe "zlib.h zlibVersion"

--- a/cabal.project.wasi
+++ b/cabal.project.wasi
@@ -1,0 +1,14 @@
+package zlib
+  flags: +bundled-c-zlib
+
+constraints: tasty >=1.5
+
+-- https://github.com/haskellari/splitmix/pull/73
+source-repository-package
+  type: git
+  location: https://github.com/amesgen/splitmix
+  tag: 83b906c4bcdc2720546f1779a16eb65e8e12ecba
+
+package splitmix
+  tests: False
+  benchmarks: False

--- a/cbits-extra/hs-zlib.c
+++ b/cbits-extra/hs-zlib.c
@@ -1,0 +1,9 @@
+#include "hs-zlib.h"
+
+void _hs_zlib_inflateEnd(z_streamp strm) {
+  inflateEnd(strm);
+}
+
+void _hs_zlib_deflateEnd(z_streamp strm) {
+  deflateEnd(strm);
+}

--- a/cbits-extra/hs-zlib.h
+++ b/cbits-extra/hs-zlib.h
@@ -1,0 +1,8 @@
+#ifndef HS_ZLIB_EXTRAS
+#define HS_ZLIB_EXTRAS
+
+#include "zlib.h"
+
+void _hs_zlib_inflateEnd(z_streamp strm);
+void _hs_zlib_deflateEnd(z_streamp strm);
+#endif

--- a/zlib.cabal
+++ b/zlib.cabal
@@ -101,7 +101,12 @@ library
   build-tools:     hsc2hs >= 0.67 && < 0.69
     -- GHC 7 ships hsc2hs-0.67
 
-  includes:        zlib.h
+  -- use `includes:` to include them when compiling
+  includes:        zlib.h hs-zlib.h
+  -- use `install-includes:` to make it part of the sdist
+  install-includes: hs-zlib.h
+  include-dirs:    cbits-extra
+  c-sources:       cbits-extra/hs-zlib.c
   ghc-options:     -Wall -fwarn-tabs
   if flag(non-blocking-ffi)
     cpp-options:   -DNON_BLOCKING_FFI


### PR DESCRIPTION
We have the signature
```c
int inflateEnd(z_streamp strm);
```
in contrast to
```haskell
type FinalizerPtr a = FunPtr (Ptr a -> IO ())
```
so we have a return type mismatch. This doesn't seem to matter on most platforms, but causes errors for WASM/WASI.

---

Also adds a CI job for GHC WASM/WASI 9.6 and 9.8.