### PR TITLE
Remove `includes` from `.cabal`-file

### DIFF
--- a/zlib-clib/zlib-clib.cabal
+++ b/zlib-clib/zlib-clib.cabal
@@ -36,7 +36,6 @@ library
   default-language: Haskell2010
 
   include-dirs: cbits
-  includes: zlib.h
 
   c-sources: cbits/adler32.c
              cbits/compress.c

--- a/zlib/zlib.cabal
+++ b/zlib/zlib.cabal
@@ -92,8 +92,6 @@ library
     build-tools:     hsc2hs < 0.68.5
     -- GHC 7 ships hsc2hs-0.67
 
-  -- use `includes:` to include them when compiling
-  includes:        zlib.h hs-zlib.h
   include-dirs:    cbits-extra
   c-sources:       cbits-extra/hs-zlib.c
   ghc-options:     -Wall -fwarn-tabs


### PR DESCRIPTION
This is useless at best, and a common source of confusion.

https://github.com/haskell/cabal/pull/10145
https://github.com/sol/hpack/issues/355