### PR TITLE
Don’t reuse huge string in test to save 4 GB RAM at runtime

### DIFF
--- a/zlib/test/Test.hs
+++ b/zlib/test/Test.hs
@@ -288,12 +288,12 @@ test_exception = ioProperty $ do
     Right{} -> counterexample "expected exception" False
 
 test_compress_large_chunk :: Property
-test_compress_large_chunk = GZip.decompress (GZip.compress xs) === xs
+test_compress_large_chunk =
+  GZip.decompress (GZip.compress (BL.replicate len 0)) === BL.replicate len 0
   where
     len = case finiteBitSize (0 :: Int) of
       64 -> (1 `shiftL` 32) + 1
       _ -> 0 -- ignore it
-    xs = BL.fromStrict $ BS.replicate len 0
 
 toStrict :: BL.ByteString -> BS.ByteString
 #if MIN_VERSION_bytestring(0,10,0)


### PR DESCRIPTION
Alleviate problem outlined in #78. With this patch `+RTS -s` shows:
```
  10,770,313,192 bytes allocated in the heap
     920,616,472 bytes copied during GC
   4,073,228,872 bytes maximum residency (11 sample(s))
     492,406,200 bytes maximum slop
            4922 MiB total memory in use (96 MiB lost due to fragmentation)
```

as opposed to baseline

```
  14,101,300,272 bytes allocated in the heap
     406,182,704 bytes copied during GC
   8,283,161,920 bytes maximum residency (7 sample(s))
     487,512,768 bytes maximum slop
            8975 MiB total memory in use (99 MiB lost due to fragmentation)
```