### PR TITLE
Make tests retain 4GB less RAM

### DIFF
--- a/zlib/test/Test.hs
+++ b/zlib/test/Test.hs
@@ -289,8 +289,12 @@ test_exception = ioProperty $ do
 
 test_compress_large_chunk :: Property
 test_compress_large_chunk =
-  GZip.decompress (GZip.compress (BL.replicate len 0)) === BL.replicate len 0
+  counterexample
+    ("Expected " ++ show len ++ " zeros but got different result, please investigate manually")
+    (property test)
   where
+    test = GZip.decompress (GZip.compress (BL.replicate len 0)) == BL.replicate len 0
+
     len = case finiteBitSize (0 :: Int) of
       64 -> (1 `shiftL` 32) + 1
       _ -> 0 -- ignore it

--- a/zlib/zlib.cabal
+++ b/zlib/zlib.cabal
@@ -130,3 +130,4 @@ test-suite tests
                    tasty            >= 0.8 && < 1.6,
                    tasty-quickcheck >= 0.8 && < 1
   ghc-options:     -Wall
+                   --with-rtsopts="-M1G"


### PR DESCRIPTION
The `===` operator holds on to inputs for error reporting which is suboptimal for 4GB input strings. Showing it in case test fails is probably not wise.

With this change the `+RTS -s` becomes
```
  10,770,647,720 bytes allocated in the heap
     491,363,192 bytes copied during GC
      84,320,336 bytes maximum residency (7 sample(s))
         372,656 bytes maximum slop
             255 MiB total memory in use (0 MiB lost due to fragmentation)
```

Given that all operations happen on lazy bytestrings it might make sense to pass `+RTS -MNNNG` to limit heap size to NNN gigabytes so that errors in streaming that lead to data being retained will get caught.