### PR TITLE
Properly limit maximum heap size when running tests to ensure streaming doesn’t hold on to data

### DIFF
--- a/zlib/zlib.cabal
+++ b/zlib/zlib.cabal
@@ -130,4 +130,4 @@ test-suite tests
                    tasty            >= 0.8 && < 1.6,
                    tasty-quickcheck >= 0.8 && < 1
   ghc-options:     -Wall
-                   --with-rtsopts="-M1G"
+                   "-with-rtsopts=-M1G"


### PR DESCRIPTION
My changes in zlib.cabal in #80 for specifying RTS flags at compile time were incorrect - `--` is treated as comment by cabal.

If I undo the fix to not retain 4GB string in master then tests don't fail. But the intention of the `with-rtsopts` was that tests would fail in such case.