### PR TITLE
Fix documentation: use correct defaultDecompressParams in examples

### DIFF
--- a/zlib/Codec/Compression/GZip.hs
+++ b/zlib/Codec/Compression/GZip.hs
@@ -91,7 +91,7 @@ decompress = decompressWith defaultDecompressParams
 -- | Like 'Codec.Compression.Gzip.decompress' but with the ability to specify various decompression
 -- parameters. Typical usage:
 --
--- > decompressWith defaultCompressParams { ... }
+-- > decompressWith defaultDecompressParams { ... }
 --
 decompressWith :: DecompressParams -> ByteString -> ByteString
 decompressWith = Internal.decompress gzipFormat

--- a/zlib/Codec/Compression/Zlib.hs
+++ b/zlib/Codec/Compression/Zlib.hs
@@ -79,7 +79,7 @@ decompress = decompressWith defaultDecompressParams
 -- | Like 'Codec.Compression.Zlib.decompress' but with the ability to specify various decompression
 -- parameters. Typical usage:
 --
--- > decompressWith defaultCompressParams { ... }
+-- > decompressWith defaultDecompressParams { ... }
 --
 decompressWith :: DecompressParams -> ByteString -> ByteString
 decompressWith = Internal.decompress zlibFormat


### PR DESCRIPTION
The documentation for decompressWith incorrectly referenced defaultCompressParams in the usage examples. Changed to use the correct defaultDecompressParams instead, which is appropriate for decompression operations.